### PR TITLE
fix: retry if resource still open

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-resource
-version: 2.0.5
+version: 2.0.6
 crystal: ">= 1.0.0"
 
 dependencies:

--- a/src/placeos-resource.cr
+++ b/src/placeos-resource.cr
@@ -126,6 +126,7 @@ abstract class PlaceOS::Resource(T)
           Log.trace { {message: "resource event", event: change.event.to_s.downcase, id: change.value.id} }
           event_channel.send(Event(T).new(change.event, change.value))
         end
+        raise "Changefeed closed prematurely" unless event_channel.closed?
       rescue e
         Log.error { {message: "while watching resources", error: e.to_s} } unless e.is_a?(Channel::ClosedError)
         raise e


### PR DESCRIPTION
If a changefeed is dropped silently, start a new one.