### PR TITLE
feat: reconnect callback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    name: 'crystal: ${{ matrix.crystal }}'
+    name: "${{ !matrix.stable && '🚧 ' || '' }}crystal: ${{ matrix.crystal }}, MT: ${{ matrix.MT && '☑' || '☐' }}"
     strategy:
       fail-fast: false
       matrix:
@@ -14,7 +14,9 @@ jobs:
         crystal:
           - 1.0.0
           - 1.1.1
-          - 1.2.0
+          - 1.2.2
+          - 1.3.1
+        MT: [true, false]
         include:
           - crystal: nightly
             stable: false
@@ -27,8 +29,8 @@ jobs:
     continue-on-error: ${{ !matrix.stable }}
     steps:
       - uses: actions/checkout@v2
-      - uses: oprypin/install-crystal@v1
+      - uses: crystal-lang/install-crystal@v1.6.0
         with:
           crystal: ${{ matrix.crystal }}
       - run: shards install --ignore-crystal-version
-      - run: crystal spec -v --error-trace
+      - run: crystal spec -v --error-trace ${{ matrix.MT && '-Dpreview_mt' || '' }} --order random

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
         include:
           - crystal: nightly
             stable: false
+            MT: false
+          - crystal: nightly
+            stable: false
+            MT: true
     services:
       rethink:
         image: rethinkdb:2.4

--- a/README.md
+++ b/README.md
@@ -1,8 +1,30 @@
 # PlaceOS Resource
 
-[![Build Status](https://travis-ci.com/place-labs/resource.svg?branch=master)](https://travis-ci.com/place-labs/resource)
+[![CI](https://github.com/place-labs/resource/actions/workflows/ci.yml/badge.svg)](https://github.com/place-labs/resource/actions/workflows/ci.yml)
 
-Abstraction over RethinkORM changefeeds
+Abstraction over [RethinkORM](https://github.com/spider-gazelle) changefeeds
+
+## Implementation
+
+`PlaceOS::Resource(T)` is a layer over `RethinkORM` models, providing an abstract interface to a table's changefeed.
+
+## `abstract def process_resource(action : Action, resource : T)`
+
+`process_resource(action : Action, resource : T)` is the only abstract method one must implement.
+On startup, the entire table is iterated asynchronously, yielding `:created` events for each model.
+
+After the initial pass, `Action::Created`, `Action::Deleted`, and `Action::Updated` events on the table are processed as they are received.
+
+### `Action::Updated`
+
+The model received with a `:updated` event has the changes applied in the form of standard [`active-model`](https://github.com/spider-gazelle/active-model) attribute changes information.
+
+
+### `def on_reconnect`
+
+A non-abstract def. In its stock form, `on_reconnect` is a noop.
+
+This method can be overwritten in inheriting classes to perform actions after a changefeed is recovered.
 
 ## Contributing
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-resource
-version: 2.2.0
+version: 2.3.0
 crystal: ">= 1.0.0"
 
 dependencies:

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -18,6 +18,12 @@ class Processor < PlaceOS::Resource(Basic)
   getter updates = [] of String
   getter deletes = [] of String
 
+  property? reconnected = false
+
+  def on_reconnect
+    self.reconnected = true
+  end
+
   def process_resource(action : PlaceOS::Resource::Action, resource : Basic) : PlaceOS::Resource::Result
     case action
     in .created? then creates


### PR DESCRIPTION
- Adds `#on_reconnect`, a method to override in implementations of the abstract resource interface

  This allows for reconnection logic and potential cleanup after loss of connection with DB
  
- Add an `Implementation` section to the readme

Closes #11 